### PR TITLE
Set errors = replace in open function calls

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ def extractContact(folder,entrywriter):
     countDict = dict()
     for file in os.listdir(folder):
         # Read the email
-        f = open(os.path.join(folder,file),'r')
+        f = open(os.path.join(folder,file),'r', errors = 'replace')
         # Parse the email
         content = email.parser.Parser().parsestr(f.read())
         f.close()
@@ -57,7 +57,7 @@ def dailyAverage(empl,inboxLoc,entryWriter):
         if (os.path.isfile(os.path.join(inboxLoc,file)) != True):
             continue
         # Read the email
-        f = open(os.path.join(inboxLoc,file),'r')
+        f = open(os.path.join(inboxLoc,file),'r',errors = 'replace')
         # Parse the email
         content = email.parser.Parser().parsestr(f.read())
         f.close()


### PR DESCRIPTION
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xbf in position 500: invalid start byte' was raised in 314. email received by whalley-g. For the scope of this exercise, we replace this byte.